### PR TITLE
Basic fix for issue #23

### DIFF
--- a/Adafruit_Thermal.cpp
+++ b/Adafruit_Thermal.cpp
@@ -66,9 +66,9 @@ void Adafruit_Thermal::timeoutSet(unsigned long x) {
 // This function waits (if necessary) for the prior task to complete.
 void Adafruit_Thermal::timeoutWait() {
   if(dtrEnabled) {
-    while(digitalRead(dtrPin) == HIGH);
+    while(digitalRead(dtrPin) == HIGH){yield();};
   } else {
-    while((long)(micros() - resumeTime) < 0L); // (syntax is rollover-proof)
+    while((long)(micros() - resumeTime) < 0L){yield();}; // (syntax is rollover-proof)
   }
 }
 


### PR DESCRIPTION
yield() added to timeoutWait() in order to feed ESP8266´s watchdog timer.
No negative effect for other Arduinos.

https://github.com/adafruit/Adafruit-Thermal-Printer-Library/issues/23